### PR TITLE
Run the latest version of Snyk in GitHub Actions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -34,18 +34,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
-
-      - name: Setup Snyk
-        uses: snyk/actions/setup@master
-        id: snyk
-        with:
-          snyk-version: latest
-
-      - name: Snyk version
-        run: echo "${{ steps.snyk.outputs.version }}"
-
-      - name: Run Snyk to check for vulnerabilities
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: snyk/actions/node@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,18 @@ jobs:
         uses: codecov/codecov-action@v2.1.0
         with:
           fail_ci_if_error: true
+
+      - name: Setup Snyk
+        uses: snyk/actions/setup@master
+        id: snyk
+        with:
+          snyk-version: latest
+
+      - name: Snyk version
+        run: echo "${{ steps.snyk.outputs.version }}"
+
+      - name: Run Snyk to check for vulnerabilities
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Snyk reports several insecure dependencies that are introduced by `snyk@1.224.0`.  Use the `snyk/actions/setup` GitHub Action to always target the latest Snyk version.