### PR TITLE
Fix `testpack` working-directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - run: yarn run lint
       - run: yarn run test
 
-      - run: npx testpack-cli --verbose --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
+      - run: npx testpack-cli --verbose --test-folder=../regex-to-strings-testpack --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
         working-directory: packages/regex-to-strings
 
       - name: Upload test coverage report to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 16.x, lts/*]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,9 @@ jobs:
       - run: yarn run lint
       - run: yarn run test
 
-      - run: npx testpack-cli --verbose --test-folder=../regex-to-strings-testpack --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
-        working-directory: packages/regex-to-strings
+      - run: |
+          cd packages/regex-to-strings
+          npx testpack-cli --verbose --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,8 @@ jobs:
       - run: yarn run lint
       - run: yarn run test
 
-      - run: |
-          cd packages/regex-to-strings
-          npx testpack-cli --verbose --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
+      - run: npx testpack-cli --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
+        working-directory: $GITHUB_WORKSPACE/packages/regex-to-strings
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.14.1, 17.8.0, 17.x]
+        node-version: [12.x]
+        require-successful-testpack: [true]
+        include:
+          - node-version: 16.x
+            require-successful-testpack: false
+          - node-version: lts/*
+            require-successful-testpack: false
 
     steps:
       - name: Checkout repository
@@ -37,8 +43,10 @@ jobs:
       - run: yarn run lint
       - run: yarn run test
 
-      - run: npx testpack-cli --test-folder=${{ github.workspace }}/packages/regex-to-strings-testpack --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
-        working-directory: ${{ github.workspace }}/packages/regex-to-strings
+      - run: npx testpack-cli --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
+        working-directory: ./packages/regex-to-strings
+        # Workaround for #66
+        continue-on-error: ${{ !matrix.require-successful-testpack }}
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - run: yarn run lint
       - run: yarn run test
 
-      - run: npx testpack-cli --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
+      - run: npx testpack-cli --verbose --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
         working-directory: packages/regex-to-strings
 
       - name: Upload test coverage report to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.14.0, 16.14.1, 16.14.2]
+        node-version: [16.14.1, 17.8.0, 17.x]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - run: yarn run test
 
       - run: npx testpack-cli --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
-        working-directory: ./packages/regex-to-strings
+        working-directory: packages/regex-to-strings
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - run: yarn run lint
       - run: yarn run test
 
-      - run: npx testpack-cli --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
+      - run: npx testpack-cli --test-folder=${{ github.workspace }}/packages/regex-to-strings-testpack --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
         working-directory: ${{ github.workspace }}/packages/regex-to-strings
 
       - name: Upload test coverage report to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - run: yarn run test
 
       - run: npx testpack-cli --keep=@types/*,ts-jest,typescript jest.config.js tsconfig.test.json src/e2e.spec.ts
-        working-directory: $GITHUB_WORKSPACE/packages/regex-to-strings
+        working-directory: ${{ github.workspace }}/packages/regex-to-strings
 
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.14.0, 16.14.1, 16.14.2]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fix CI errors during testpack due to sub-directory confusion.

```
npm WARN tarball tarball data for regex-to-strings@file:packages/regex-to-strings/regex-to-strings-2.1.0.tgz (null) seems to be corrupted. Trying again.
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path /home/runner/work/regex-to-strings/regex-to-strings/packages/regex-to-strings-testpack/packages/regex-to-strings/regex-to-strings-2.1.0.tgz
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, open '/home/runner/work/regex-to-strings/regex-to-strings/packages/regex-to-strings-testpack/packages/regex-to-strings/regex-to-strings-2.1.0.tgz'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 
```